### PR TITLE
Use a nested query to save a rountrip

### DIFF
--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -8,15 +8,7 @@ module FastPage
 
       id_scope = dup
       id_scope = id_scope.except(:includes) unless references_eager_loaded_tables?
-      ids = id_scope.pluck(:id)
-
-      if ids.empty?
-        @records = []
-        @loaded = true
-        return self
-      end
-
-      @records = where(id: ids).unscope(:limit).unscope(:offset).load
+      @records = where(id: id_scope).unscope(:limit).unscope(:offset).load
       @loaded = true
 
       self

--- a/test/pagy_test.rb
+++ b/test/pagy_test.rb
@@ -47,11 +47,10 @@ class PagyTest < Minitest::Test
     assert_equal 1, pagy.page
     assert_equal 2, pagy.next
     assert_equal 5, records.size
-    assert_equal 3, queries.size
+    assert_equal 2, queries.size
 
     assert_includes queries, 'SELECT COUNT(*) FROM "users"'
-    assert_includes queries, 'SELECT "users"."id" FROM "users" LIMIT ? OFFSET ?'
-    assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?)'
+    assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (SELECT "users"."id" FROM "users" LIMIT ? OFFSET ?)'
 
     ActiveSupport::Notifications.unsubscribe("sql.active_record")
   end


### PR DESCRIPTION
There might be a reason that escapes me, but I don't get why the gem is doing a full roundtrip to fetch the ids. Active Record supports nested queries just fine.