### PR TITLE
Make compatible with Kaminari without_count

### DIFF
--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -6,9 +6,19 @@ module FastPage
       # Must have a limit or offset defined
       raise ArgumentError, "You must specify a limit or offset to use fast_page" if !limit_value && !offset_value
 
+      # We load 1 additional record to determine if there is a next page.
+      # This helps us avoid doing a count over all records
+      @values[:limit] = limit_value + 1 if limit_value
       id_scope = dup
       id_scope = id_scope.except(:includes) unless references_eager_loaded_tables?
       ids = id_scope.pluck(:id)
+
+      if limit_value
+        @values[:limit] = limit_value - 1
+        # Record if there is a next page
+        @_has_next = ids.length > limit_value
+        ids = ids.first(limit_value)
+      end
 
       if ids.empty?
         @records = []

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -71,7 +71,8 @@ class FastPageTest < Minitest::Test
     og = User.all.limit(5).offset(5).order(created_at: :desc)
     fast = User.all.limit(5).offset(5).order(created_at: :desc).fast_page
 
-    assert_equal og, fast
+    assert_equal og.length, fast.length
+    assert_equal og.select(&:id), fast.select(&:id)
   end
 
   def test_errors_without_limit_or_offset
@@ -84,7 +85,8 @@ class FastPageTest < Minitest::Test
     og = User.all.limit(5).order(created_at: :desc)
     fast = User.all.limit(5).order(created_at: :desc).fast_page
 
-    assert_equal og, fast
+    assert_equal og.length, fast.length
+    assert_equal og.select(&:id), fast.select(&:id)
   end
 
   def test_works_offset_only

--- a/test/kaminari_test.rb
+++ b/test/kaminari_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "pry"
 
 require "kaminari"
 
@@ -26,7 +27,19 @@ class KaminariTest < Minitest::Test
     og_page = User.page(2).per(1).order(created_at: :desc)
     fast_page = User.page(2).per(1).order(created_at: :desc).fast_page
 
-    assert_equal og_page, fast_page
+    assert_equal og_page.length, fast_page.length
+    assert_equal og_page.first.id, fast_page.first.id
+    assert_equal og_page.current_page, fast_page.current_page
+    assert_equal og_page.next_page, fast_page.next_page
+    assert_equal og_page.prev_page, fast_page.prev_page
+  end
+
+  def test_kaminari_works_without_count
+    og_page = User.page(2).per(1).order(created_at: :desc).without_count
+    fast_page = User.page(2).per(1).order(created_at: :desc).without_count.fast_page
+
+    assert_equal og_page.length, fast_page.length
+    assert_equal og_page.first.id, fast_page.first.id
     assert_equal og_page.current_page, fast_page.current_page
     assert_equal og_page.next_page, fast_page.next_page
     assert_equal og_page.prev_page, fast_page.prev_page

--- a/test/kaminari_test.rb
+++ b/test/kaminari_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require "pry"
 
 require "kaminari"
 


### PR DESCRIPTION
Found this bug while using `fast_page` with `without_count`.

## How `without_count` works.
Kaminari's `without_count` stops Kaminari from doing a full count on the scope. [See here](https://github.com/kaminari/kaminari#paginating-without-issuing-select-count-query).

Kaminari does this by overriding the `load` method to load in an additional record. If the returned records is > than the user requested limit, then we know there is another page.

## Problem
`fast_page` wasn't compatible with this because we force the records to be loaded early. This means the kaminari code was never getting hit.

## The fix
This PR updates `fast_page` to use the same technique and also sets a `@_has_next` ivar that kaminari then uses to skip executing the full count.