### PR TITLE
Return array from fast_page.to_a

### DIFF
--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -26,7 +26,7 @@ module FastPage
         return self
       end
 
-      @records = where(id: ids).unscope(:limit).unscope(:offset).load
+      @records = where(id: ids).unscope(:limit).unscope(:offset).load.records
       @loaded = true
 
       self

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -95,4 +95,8 @@ class FastPageTest < Minitest::Test
 
     assert_equal og, fast
   end
+
+  def test_to_a_returns_an_array
+    assert_equal Array, User.all.limit(5).fast_page.to_a.class
+  end
 end


### PR DESCRIPTION
The load method returns the `ActiveRecord` relation rather than the `Array` of records that has been loaded.

As `to_a` dups and returns `records` it would also return the `ActiveRecord` relation rather than an `Array`.