### PR TITLE
Return only unique record when using includes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -11,7 +11,7 @@ module FastPage
       @values[:limit] = limit_value + 1 if limit_value
       id_scope = dup
       id_scope = id_scope.except(:includes) unless references_eager_loaded_tables?
-      ids = id_scope.distinct.pluck(:id)
+      ids = id_scope.pluck(:id).to_set
 
       if limit_value
         @values[:limit] = limit_value - 1

--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -11,7 +11,7 @@ module FastPage
       @values[:limit] = limit_value + 1 if limit_value
       id_scope = dup
       id_scope = id_scope.except(:includes) unless references_eager_loaded_tables?
-      ids = id_scope.pluck(:id).to_set
+      ids = id_scope.pluck(:id).uniq
 
       if limit_value
         @values[:limit] = limit_value - 1

--- a/lib/fast_page/active_record_methods.rb
+++ b/lib/fast_page/active_record_methods.rb
@@ -11,7 +11,7 @@ module FastPage
       @values[:limit] = limit_value + 1 if limit_value
       id_scope = dup
       id_scope = id_scope.except(:includes) unless references_eager_loaded_tables?
-      ids = id_scope.pluck(:id)
+      ids = id_scope.distinct.pluck(:id)
 
       if limit_value
         @values[:limit] = limit_value - 1

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -103,4 +103,12 @@ class FastPageTest < Minitest::Test
   def test_to_a_returns_an_array
     assert_equal Array, User.all.limit(5).fast_page.to_a.class
   end
+
+  def test_returns_unique_records_when_including_associations
+    og = User.includes(:organizations).where(organizations: { id: Organization.pluck(:id) }).limit(2).order(created_at: :asc)
+    fast = User.includes(:organizations).where(organizations: { id: Organization.pluck(:id) }).limit(2).order(created_at: :asc).fast_page
+
+    assert_equal og.length, fast.length
+    assert_equal og.select(&:id), fast.select(&:id)
+  end
 end

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -14,7 +14,7 @@ class FastPageTest < Minitest::Test
     User.create(login: "mikeissocool", organizations: [organizations[0], organizations[1]])
     User.create(login: "iheanyi", organizations: [organizations[0], organizations[1]])
     User.create(login: "nicknicknick", organizations: [organizations[0]])
-    User.create(login: "frances")
+    User.create(login: "frances", organizations: [organizations[1]])
     User.create(login: "phani")
     User.create(login: "jason")
     User.create(login: "derek")

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -44,7 +44,7 @@ class FastPageTest < Minitest::Test
     User.all.limit(5).fast_page
 
     assert_equal 2, queries.size
-    assert_includes queries, 'SELECT "users"."id" FROM "users" LIMIT ?'
+    assert_includes queries, 'SELECT DISTINCT "users"."id" FROM "users" LIMIT ?'
     assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?)'
 
     ActiveSupport::Notifications.unsubscribe("sql.active_record")
@@ -62,7 +62,7 @@ class FastPageTest < Minitest::Test
     assert_equal 4, queries.size
 
     # Organizations are not included on the ID query (not needed)
-    assert_includes queries, 'SELECT "users"."id" FROM "users" LIMIT ?'
+    assert_includes queries, 'SELECT DISTINCT "users"."id" FROM "users" LIMIT ?'
     assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     # Includes are still loaded
     assert_includes queries, 'SELECT "user_organizations".* FROM "user_organizations" WHERE "user_organizations"."user_id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'

--- a/test/fast_page_test.rb
+++ b/test/fast_page_test.rb
@@ -44,7 +44,7 @@ class FastPageTest < Minitest::Test
     User.all.limit(5).fast_page
 
     assert_equal 2, queries.size
-    assert_includes queries, 'SELECT DISTINCT "users"."id" FROM "users" LIMIT ?'
+    assert_includes queries, 'SELECT "users"."id" FROM "users" LIMIT ?'
     assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?)'
 
     ActiveSupport::Notifications.unsubscribe("sql.active_record")
@@ -62,7 +62,7 @@ class FastPageTest < Minitest::Test
     assert_equal 4, queries.size
 
     # Organizations are not included on the ID query (not needed)
-    assert_includes queries, 'SELECT DISTINCT "users"."id" FROM "users" LIMIT ?'
+    assert_includes queries, 'SELECT "users"."id" FROM "users" LIMIT ?'
     assert_includes queries, 'SELECT "users".* FROM "users" WHERE "users"."id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     # Includes are still loaded
     assert_includes queries, 'SELECT "user_organizations".* FROM "user_organizations" WHERE "user_organizations"."user_id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,9 +16,14 @@ ActiveRecord::Schema.define do
 
   create_table :users, force: true do |t|
     t.string :login
-    t.integer :organization_id
     t.timestamps
     t.index ["login"], unique: true
+  end
+
+  create_table :user_organizations, force: true do |t|
+    t.integer :user_id
+    t.integer :organization_id
+    t.timestamps
   end
 
   create_table :organizations, force: true do |t|
@@ -31,5 +36,5 @@ class Organization < ActiveRecord::Base
 end
 
 class User < ActiveRecord::Base
-  belongs_to :organization
+  has_and_belongs_to_many :organizations, join_table: "user_organizations"
 end


### PR DESCRIPTION
### The problem

In some cases when a query is using `includes` and the included tables are used in the `where` clauses, the returned results seems to be duplicated and in the end, it returns too little records compared to set `limit`. Example from specs:

```
User.includes(:organizations).where(organizations: { id: Organization.pluck(:id) }).limit(2).order(created_at: :asc)
[#<User id: 1, login: "mikeissocool", created_at: "2023-05-30 10:26:12", updated_at: "2023-05-30 10:26:12">, #<User id: 2, login: "iheanyi", created_at: "2023-05-30 10:26:12", updated_at: "2023-05-30 10:26:12">]

User.includes(:organizations).where(organizations: { id: Organization.pluck(:id) }).limit(2).order(created_at: :asc).fast_page
[#<User id: 1, login: "mikeissocool", created_at: "2023-05-30 10:26:12", updated_at: "2023-05-30 10:26:12">]
```

It's happening because at some point (when `pluck` is called) a SQL `JOIN` is executed and if the `JOIN` operation multiplies the results, the `ids` contains duplicated record IDs. This way, when the `ids.first(limit_value)` is called, it takes first `limit_value` values from a duplicated set.

### The solution
I propose to call `uniq` after taking the `ids` and this way, operating on a unique set of record IDs